### PR TITLE
User configurable community string

### DIFF
--- a/bin/trapperkeeper
+++ b/bin/trapperkeeper
@@ -49,6 +49,9 @@ def main():
     config = Config.from_file(args.config)
 
     db_engine = get_db_engine(config["database"])
+    community = config["community"]
+    if not community:
+        community = "public"
     Session.configure(bind=db_engine)
 
     conn = Session()
@@ -56,7 +59,7 @@ def main():
     template_env = get_template_env(
         hostname_or_ip=resolver.hostname_or_ip
     )
-    cb = TrapperCallback(conn, template_env, config, resolver)
+    cb = TrapperCallback(conn, template_env, config, resolver, community)
 
     logging.basicConfig(
         level=get_loglevel(args),

--- a/conf/trapperkeeper.yaml
+++ b/conf/trapperkeeper.yaml
@@ -111,3 +111,7 @@ config:
     # Type: int
     stats_port: 8889
 
+    # Accept traps for this SNMP community.
+    #
+    # Type: str
+    community: "public"

--- a/tests/send_traps.sh
+++ b/tests/send_traps.sh
@@ -4,7 +4,9 @@ BASE_DIR=$( dirname $0 )
 
 DEST="localhost"
 COMMON_OPTS="-Ln -mTRAPPERKEEPER-MIB -M+"${BASE_DIR}/mibs" -c public"
+PRIV_COMMON_OPTS="-Ln -mTRAPPERKEEPER-MIB -M+"${BASE_DIR}/mibs" -c private"
 SYSLOC_VARBIND="SNMPv2-MIB::sysLocation.0 s TrapperKeeper-Test"
 
 snmptrap -v 1 $COMMON_OPTS $DEST TRAPPERKEEPER-MIB::testtraps "" 6 1 "" $SYSLOC_VARBIND
 snmptrap -v 2c $COMMON_OPTS $DEST "" TRAPPERKEEPER-MIB::testV2Trap $SYSLOC_VARBIND
+snmptrap -v 1 $PRIV_COMMON_OPTS $DEST TRAPPERKEEPER-MIB::testtraps "" 6 1 "" $SYSLOC_VARBIND


### PR DESCRIPTION
Users can specify a community string in trapperkeeper.yaml. If
trapperkeeper recieves a trap whose community string doesn't match the
configured community string, trapperkeepr will discard the trap and log
a message:

WARNING:root:Trapperkeeper community is: public, received trap with
community: private..discarding