### PR TITLE
IPv6 Support For Trapperkeeper

### DIFF
--- a/bin/trapperkeeper
+++ b/bin/trapperkeeper
@@ -5,7 +5,7 @@ from expvar.stats import stats
 import logging
 import oid_translate
 from pysnmp.carrier.asynsock.dispatch import AsynsockDispatcher
-from pysnmp.carrier.asynsock.dgram import udp
+from pysnmp.carrier.asynsock.dgram import udp, udp6
 import threading
 import tornado.ioloop
 import tornado.web
@@ -52,6 +52,9 @@ def main():
     community = config["community"]
     if not community:
         community = None
+    ipv6_server = config["ipv6"]
+    if not ipv6_server:
+        ipv6_server = None
     Session.configure(bind=db_engine)
 
     conn = Session()
@@ -68,6 +71,10 @@ def main():
 
     transport_dispatcher = AsynsockDispatcher()
     transport_dispatcher.registerRecvCbFun(cb)
+    if ipv6_server:
+        transport_dispatcher.registerTransport(
+            udp6.domainName, udp6.Udp6SocketTransport().openServerMode(("::1", int(config["trap_port"])))
+        )
     transport_dispatcher.registerTransport(
         udp.domainName, udp.UdpSocketTransport().openServerMode(("0.0.0.0", int(config["trap_port"])))
     )

--- a/conf/trapperkeeper.yaml
+++ b/conf/trapperkeeper.yaml
@@ -116,3 +116,8 @@ config:
     #
     # Type: str
     community: null
+
+    # Listen for traps on an IPv6 address
+    #
+    # Type: bool
+    ipv6: false

--- a/tests/send_traps.sh
+++ b/tests/send_traps.sh
@@ -3,6 +3,7 @@
 BASE_DIR=$( dirname $0 )
 
 DEST="localhost"
+IPv6_DEST="udp6:[::1]:162"
 COMMON_OPTS="-Ln -mTRAPPERKEEPER-MIB -M+"${BASE_DIR}/mibs" -c public"
 PRIV_COMMON_OPTS="-Ln -mTRAPPERKEEPER-MIB -M+"${BASE_DIR}/mibs" -c private"
 SYSLOC_VARBIND="SNMPv2-MIB::sysLocation.0 s TrapperKeeper-Test"
@@ -10,3 +11,7 @@ SYSLOC_VARBIND="SNMPv2-MIB::sysLocation.0 s TrapperKeeper-Test"
 snmptrap -v 1 $COMMON_OPTS $DEST TRAPPERKEEPER-MIB::testtraps "" 6 1 "" $SYSLOC_VARBIND
 snmptrap -v 2c $COMMON_OPTS $DEST "" TRAPPERKEEPER-MIB::testV2Trap $SYSLOC_VARBIND
 snmptrap -v 1 $PRIV_COMMON_OPTS $DEST TRAPPERKEEPER-MIB::testtraps "" 6 1 "" $SYSLOC_VARBIND
+
+snmptrap -v 1 $COMMON_OPTS $IPv6_DEST TRAPPERKEEPER-MIB::testtraps "" 6 1 "" $SYSLOC_VARBIND
+snmptrap -v 2c $COMMON_OPTS $IPv6_DEST "" TRAPPERKEEPER-MIB::testV2Trap $SYSLOC_VARBIND
+snmptrap -v 1 $PRIV_COMMON_OPTS $IPv6_DEST TRAPPERKEEPER-MIB::testtraps "" 6 1 "" $SYSLOC_VARBIND


### PR DESCRIPTION
When the ipv6 boolean (defaults to false) in trapperkeeper's yaml config is set to
true, trapperkeeper will listen on both IPv6 and IPv4 ports for SNMP
traps.

Added IPv6 testcases to send_traps.sh.