### PR TITLE
as the sender of mail handler is invalid, fix this use default sender…

### DIFF
--- a/trapperkeeper/callbacks.py
+++ b/trapperkeeper/callbacks.py
@@ -64,7 +64,7 @@ class TrapperCallback(object):
         ctxt = dict(trap=trap, dest_host=self.hostname)
         try:
             stats.incr("mail_sent_attempted", 1)
-            send_trap_email(recipients, "trapperkeeper",
+            send_trap_email(recipients, "trapperkeeper@localhost",
                             subject, self.template_env, ctxt)
             stats.incr("mail_sent_successful", 1)
         except socket.error as err:


### PR DESCRIPTION
… address < trapperkeeper@localhost>

ERROR:root:Callback Failed: (501, '<trapperkeeper>: sender address must contain a domain', 'trapperkeeper')
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/trapperkeeper/callbacks.py", line 43, in **call**
    self._call(_args, *_kwargs)
  File "build/bdist.linux-x86_64/egg/trapperkeeper/callbacks.py", line 171, in _call
    self._send_mail(handler, trap, duplicate)
  File "build/bdist.linux-x86_64/egg/trapperkeeper/callbacks.py", line 72, in _send_mail
    subject, self.template_env, ctxt)
  File "build/bdist.linux-x86_64/egg/trapperkeeper/utils.py", line 127, in send_trap_email
    smtp.sendmail(sender, recipients, msg.as_string())
  File "/usr/lib/python2.7/smtplib.py", line 731, in sendmail
    raise SMTPSenderRefused(code, resp, from_addr)
SMTPSenderRefused: (501, '<trapperkeeper>: sender address must contain a domain', 'trapperkeeper')
