### PR TITLE
Make sender address configurable, default to trapperkeeper@localhost

### DIFF
--- a/conf/trapperkeeper.yaml
+++ b/conf/trapperkeeper.yaml
@@ -44,6 +44,11 @@ defaults:
         # Type: str
         recipients: "root@localhost"
 
+        # The sender of the message. Defaults to "trapperkeeper@localhost".
+        #
+        # Type: str
+        sender: "trapperkeeper@localhost"
+
     # When running multiple instances of trapperkeeper as a manager for a
     # given device, the message will be deduplicated in the database. If
     # you want the e-mail to be sent even when the message has been

--- a/trapperkeeper/callbacks.py
+++ b/trapperkeeper/callbacks.py
@@ -54,6 +54,7 @@ class TrapperCallback(object):
         recipients = handler["mail"].get("recipients")
         if not recipients:
             return
+        sender = handler["mail"].get("sender", "trapperkeeper@localhost")
 
         subject = handler["mail"]["subject"] % {
             "trap_oid": trap.oid,
@@ -64,7 +65,7 @@ class TrapperCallback(object):
         ctxt = dict(trap=trap, dest_host=self.hostname)
         try:
             stats.incr("mail_sent_attempted", 1)
-            send_trap_email(recipients, "trapperkeeper",
+            send_trap_email(recipients, sender,
                             subject, self.template_env, ctxt)
             stats.incr("mail_sent_successful", 1)
         except socket.error as err:


### PR DESCRIPTION
Adding @localhost to the default sender makes it more likely to work out of the box.